### PR TITLE
accept flexible taikofile

### DIFF
--- a/index.js
+++ b/index.js
@@ -79,7 +79,8 @@ const printEnvironments = function (params, commands) {
     });
     let scripts = `let screenshotCounter = 0\n`;
     for (const [i, command] of commands.entries()) {
-      if (browserActions.some(action => command.includes(action)) || pageActions.some(action => command.includes(action))) {
+      if (browserActions.some(action => command.includes(action)) || pageActions.some(action => command.includes(action))
+          || command.includes('waitFor')) {
         scripts += `await ${command}\n`
         if (params.takeScreenshot) {
           scripts += "await screenshot({ path: `./screenshot/screenshot-${screenshotCounter++}.png` })\n";


### PR DESCRIPTION
Close #1 

# このPRでやったこと
- `screenshot`を毎操作ごとに取るかどうかのフラグ変数名を`screenshot`から`takeScreenshot`に変更した。
- Taikofileを下のようにfor文などを使えるようにした。

Taikofile
```
for (let i = 0; i < 2; i++) {
    goto(url)
}
```

```
 $ taiko index.js --observe -- '{ "url": "https://yesod.co/", "takeScreenhot": true}'
```